### PR TITLE
fix(map): disable mapping and responsive view for photos

### DIFF
--- a/src/pages/mapav/components/CardTree/CardTree.module.css
+++ b/src/pages/mapav/components/CardTree/CardTree.module.css
@@ -356,9 +356,47 @@
     height: 100vh;
   }
 
+  .cardTreeMobile {
+    max-width: 100%;
+  }
+
   .cardInner {
-    min-width: 100vw;
+    min-width: 100%;
+    max-width: 100%;
     min-height: 100vh;
     height: 100vh;
+  }
+
+  .cardBody {
+    padding: 16px;
+    gap: 16px;
+  }
+
+  .cardBody .treeInfo .headerTitle h2 {
+    font-size: 28px;
+  }
+
+  .cardBody .treeInfo .info {
+    flex-direction: column;
+  }
+
+  .cardBody .treeInfo .info .picture {
+    max-width: 100%;
+  }
+
+  .cardBody .treeInfo .estadoMapeo {
+    flex-wrap: wrap;
+    justify-content: stretch;
+    gap: 8px;
+  }
+
+  .cardBody .treeMonitoring .monitoring {
+    flex-direction: column;
+  }
+
+  .cardBody .treeMonitoring .monitoring .monitoringPicture {
+    max-width: 100%;
+    min-width: 0;
+    width: 100%;
   }
 }

--- a/src/pages/mapav/components/CardTree/TreePhotoGallery.jsx
+++ b/src/pages/mapav/components/CardTree/TreePhotoGallery.jsx
@@ -97,6 +97,7 @@ export function TreePhotoGallery({ photos, galleryKey, children }) {
       {photos.length > 0 && (
         <PhotoSlider
           key={galleryKey}
+          className={styles.photoSliderPortal}
           images={sliderImages}
           visible={visible}
           index={activeIndex}

--- a/src/pages/mapav/components/CardTree/TreePhotoGallery.module.css
+++ b/src/pages/mapav/components/CardTree/TreePhotoGallery.module.css
@@ -1,6 +1,16 @@
+.photoSliderPortal {
+  z-index: 10050 !important;
+}
+
+:global(.PhotoView-Portal) {
+  z-index: 10050 !important;
+}
+
 .toolbar {
   display: flex;
   align-items: center;
+  flex-wrap: nowrap;
+  justify-content: flex-end;
   gap: 4px;
 }
 
@@ -18,6 +28,8 @@
   cursor: pointer;
   opacity: 0.85;
   transition: opacity 0.2s, background-color 0.2s;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .toolbarButton:hover:not(:disabled) {
@@ -56,6 +68,8 @@
   width: 100%;
   height: 100%;
   display: block;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .clickablePhoto img {
@@ -66,9 +80,10 @@
 }
 
 .estadoImgButton {
-  width: 100%;
+  flex: 1 1 calc(50% - 4px);
+  min-width: 0;
   background-color: var(--geyser-100);
-  padding: 8px;
+  padding: 10px 8px;
   border-radius: 6px;
   border: none;
   font-size: inherit;
@@ -77,6 +92,8 @@
   text-align: center;
   cursor: zoom-in;
   transition: background-color 0.2s;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .estadoImgButton:hover:not(:disabled) {
@@ -89,10 +106,74 @@
 }
 
 .estadoImgDisabled {
-  width: 100%;
+  flex: 1 1 calc(50% - 4px);
+  min-width: 0;
   background-color: var(--geyser-100);
-  padding: 8px;
+  padding: 10px 8px;
   border-radius: 6px;
   opacity: 0.45;
   text-align: center;
+}
+
+@media (max-width: 768px) {
+  :global(.PhotoView-Slider__BannerWrap) {
+    height: 44px;
+    min-height: 44px;
+    padding: 0 calc(4px + env(safe-area-inset-right, 0px)) 0 calc(4px + env(safe-area-inset-left, 0px));
+    padding-top: env(safe-area-inset-top, 0px);
+    flex-wrap: nowrap;
+    gap: 0;
+  }
+
+  :global(.PhotoView-Slider__BannerRight) {
+    flex: 0 0 auto;
+    flex-wrap: nowrap;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0;
+    height: 100%;
+  }
+
+  :global(.PhotoView-Slider__Counter) {
+    flex: 0 0 auto;
+    font-size: 13px;
+    padding: 0 8px;
+    white-space: nowrap;
+  }
+
+  :global(.PhotoView-Slider__toolbarIcon) {
+    flex: 0 0 auto;
+    width: 40px;
+    height: 40px;
+    padding: 8px;
+  }
+
+  .toolbar {
+    flex-wrap: nowrap;
+    justify-content: flex-end;
+    width: auto;
+    flex-shrink: 0;
+  }
+
+  .toolbarButton {
+    width: 40px;
+    height: 40px;
+    flex-shrink: 0;
+  }
+
+  .caption {
+    bottom: max(16px, env(safe-area-inset-bottom, 16px));
+    left: 16px;
+    right: 16px;
+    transform: none;
+    max-width: none;
+    font-size: 14px;
+    padding: 8px 12px;
+  }
+
+  .estadoImgButton,
+  .estadoImgDisabled {
+    flex: 1 1 calc(50% - 4px);
+    font-size: 13px;
+  }
 }

--- a/src/pages/mapav/components/MapWrapper/MapWrapper.jsx
+++ b/src/pages/mapav/components/MapWrapper/MapWrapper.jsx
@@ -112,15 +112,16 @@ export const MapWrapper = () => {
 
   return (
     <div className={styles.map}>
-      {
+      
+      {/*
         selectedCoords && (
           <div className={styles.mapControls}>
-            {/* <button onClick={dispatch(setShowTreeMappingForm(true))}>Adoptar Arbol</button> */}
             <button onClick={() => dispatch(setModalState("OPEN"))} >Mapear Arbol</button>
             <button onClick={() => dispatch(setSelectedCoords(null))}><X /></button>
           </div>
         )
-      }
+      */}
+      
 
       <MapContainer
         center={[-17.3917, -66.1448]}
@@ -136,7 +137,7 @@ export const MapWrapper = () => {
         />
 
         <MapEvents />
-        <ClickableMarker position={selectedCoords} icon={customIcon} />
+        {/* <ClickableMarker position={selectedCoords} icon={customIcon} /> */}
 
         {geoMode === "scouts" && <GeoJSON data={geoScouts} onEachFeature={onEachFeature} />}
 

--- a/src/pages/mapav/components/MapWrapper/Utils/MapEvents.jsx
+++ b/src/pages/mapav/components/MapWrapper/Utils/MapEvents.jsx
@@ -7,12 +7,12 @@ export const MapEvents = () => {
   const dispatch = useDispatch();
   const { selectedCoords, zoom, duration } = useSelector((state) => state.mapa)
   const map = useMap();
-  useMapEvents({
-    click(e) {
-      const { lat, lng } = e.latlng;
-      dispatch(setSelectedCoords([lat, lng]));
-    },
-  })
+  // useMapEvents({
+  //   click(e) {
+  //     const { lat, lng } = e.latlng;
+  //     dispatch(setSelectedCoords([lat, lng]));
+  //   },
+  // })
 
   useEffect(() => {
     if (selectedCoords) {


### PR DESCRIPTION
### 🚀 Cambios realizados

- Se deshabilitó la aparición de la opción de mapear cuando se hace clic en un punto vacío del mapa.
- Se volvió responsivo la galería de imágenes que se muestra cuando se presiona la foto en el detalle del árbol.